### PR TITLE
Add support for CJSON

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -75,9 +75,22 @@ function formatError(input, msg, position, lineno, column, json5) {
 
 function parse(input, options) {
   // parse as a standard JSON mode
-  var json5 = !(options.mode === 'json' || options.legacy)
+  var json5 = false;
+  var cjson = false;
+
+  if (options.legacy || options.mode === 'json') {
+    // use json
+  } else if (options.mode === 'cjson') {
+    cjson = true;
+  } else if (options.mode === 'json5') {
+    json5 = true;
+  } else {
+    // use it by default
+    json5 = true;
+  }
+
   var isLineTerminator = json5 ? Uni.isLineTerminator : Uni.isLineTerminatorJSON
-  var isWhiteSpace = json5 ? Uni.isWhiteSpace : Uni.isWhiteSpaceJSON
+  var isWhiteSpace     = json5 ? Uni.isWhiteSpace     : Uni.isWhiteSpaceJSON
 
   var length = input.length
     , lineno = 0
@@ -257,7 +270,7 @@ function parse(input, options) {
         // nothing
 
       } else if (chr === '/'
-             && json5
+             && (json5 || cjson)
              && (input[position] === '/' || input[position] === '*')
       ) {
         position--

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -38,7 +38,7 @@ var hasOwnProperty = Object.prototype.hasOwnProperty
 var escapable = /[\x00-\x1f\x7f-\x9f\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/
 
 function _stringify(object, options, recursiveLvl, currentKey) {
-  var opt_json = options.mode === 'json'
+  var json5 = (options.mode === 'json5' || !options.mode)
   /*
    * Opinionated decision warning:
    *
@@ -114,18 +114,18 @@ function _stringify(object, options, recursiveLvl, currentKey) {
       var chr = key.charCodeAt(i)
 
       if (chr < 0x10) {
-        if (chr === 0 && !opt_json) {
+        if (chr === 0 && json5) {
           result += '\\0'
-        } else if (chr >= 8 && chr <= 13 && (!opt_json || chr !== 11)) {
+        } else if (chr >= 8 && chr <= 13 && (json5 || chr !== 11)) {
           result += special_chars[chr]
-        } else if (!opt_json) {
+        } else if (json5) {
           result += '\\x0' + chr.toString(16)
         } else {
           result += '\\u000' + chr.toString(16)
         }
 
       } else if (chr < 0x20) {
-        if (!opt_json) {
+        if (json5) {
           result += '\\x' + chr.toString(16)
         } else {
           result += '\\u00' + chr.toString(16)
@@ -149,7 +149,7 @@ function _stringify(object, options, recursiveLvl, currentKey) {
 
       } else if (options.ascii || Uni.isLineTerminator(key[i]) || escapable.exec(key[i])) {
         if (chr < 0x100) {
-          if (!opt_json) {
+          if (json5) {
             result += '\\x' + chr.toString(16)
           } else {
             result += '\\u00' + chr.toString(16)
@@ -256,7 +256,7 @@ function _stringify(object, options, recursiveLvl, currentKey) {
           // information needlessly?
           return '-0'
         }
-        if (options.mode === 'json' && !Number.isFinite(object)) {
+        if (!json5 && !Number.isFinite(object)) {
           // json don't support infinity (= sucks)
           return 'null'
         }
@@ -343,9 +343,9 @@ module.exports.stringify = function stringifyJSON(object, options, _space) {
   if (options.indent == null) options.indent = '\t'
   if (options.quote == null) options.quote = "'"
   if (options.ascii == null) options.ascii = false
-  if (options.mode == null) options.mode = 'simple'
+  if (options.mode == null) options.mode = 'json5'
 
-  if (options.mode === 'json') {
+  if (options.mode === 'json' || options.mode === 'cjson') {
     // json only supports double quotes (= sucks)
     options.quote = '"'
 

--- a/test/test_modes.js
+++ b/test/test_modes.js
@@ -1,0 +1,30 @@
+var assert = require('assert')
+var jju = require('..')
+
+// plain json
+assert.deepEqual(jju.parse('{ "c": 123 }', { legacy: true }),  { c: 123 })
+assert.deepEqual(jju.parse('{ "c": 123 }', { mode: 'json' }),  { c: 123 })
+assert.deepEqual(jju.parse('{ "c": 123 }', { mode: 'cjson' }), { c: 123 })
+assert.deepEqual(jju.parse('{ "c": 123 }', { mode: 'json5' }), { c: 123 })
+
+// cjson
+assert.throws(function () {
+  jju.parse('{ "c": /* foo */ 123 }', { legacy: true })
+}, /No value found/)
+assert.throws(function () {
+  jju.parse('{ "c": /* foo */ 123 }', { mode: 'json' })
+}, /No value found/)
+assert.deepEqual(jju.parse('{ "c": /* foo */ 123 }', { mode: 'cjson' }), { c: 123 })
+assert.deepEqual(jju.parse('{ "c": /* foo */ 123 }', { mode: 'json5' }), { c: 123 })
+
+// json5
+assert.throws(function () {
+  jju.parse('{ "c": Infinity }', { legacy: true })
+}, /No value found/)
+assert.throws(function () {
+  jju.parse('{ "c": Infinity }', { mode: 'json' })
+}, /No value found/)
+assert.throws(function () {
+  jju.parse('{ "c": Infinity }', { mode: 'cjson' })
+}, /No value found/)
+assert.deepEqual(jju.parse('{ "c": Infinity }', { mode: 'json5' }), { c: Infinity })

--- a/test/test_stringify.js
+++ b/test/test_stringify.js
@@ -87,3 +87,8 @@ assert.equal('{a: 1, b: 2, z: 3}', stringify({b:2,a:1,z:3}, {sort_keys: 1}))
 assert.equal('{a: 1, b: {a: 2, b: 5, c: 1}, z: 3}', stringify({b:{c:1,a:2,b:5},a:1,z:3}, {sort_keys: 1}))
 assert.equal('{a: [3, 5, 1], b: 2, z: 3}', stringify({b:2,a:[3,5,1],z:3}, {sort_keys: 1}))
 assert.equal('{b: 2, a: 1, z: 3}', stringify({b:2,a:1,z:3}, {sort_keys: 0}))
+
+// modes
+assert.equal(stringify({ c: Infinity }, { mode: 'json'  }), '{"c": null}')
+assert.equal(stringify({ c: Infinity }, { mode: 'cjson' }), '{"c": null}')
+assert.equal(stringify({ c: Infinity }, { mode: 'json5' }), '{c: Infinity}')


### PR DESCRIPTION
Now you can parse cjson files (plain json files with comments), if you set "mode: 'cjson'" in options:

``` js
> require('jju').parse('{ "foo": /* bar */ "baz" }', { mode: 'cjson' })
{ foo: 'baz' }

> require('jju').parse('{ foo: /* bar */ "baz" }', { mode: 'cjson' })
SyntaxError: Unexpected token 'f' at 1:3
{ foo: /* bar */ "baz" }
  ^
    at SyntaxError (native)
```

ref #8, #17
