### PR TITLE
No duplicate object keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ parse('{hasOwnProperty: 1, x: 2}', {reserved_keys: 'replace'}).hasOwnProperty('x
 
  - mode - operation mode, set it to 'json' if you want to throw on non-strict json files (String)
 
+ - no_duplicate_keys - throw an error, if the same key repeats in the same object (Boolean). Strict JSON specification allows it, but it is often a mistake, because only the last value will "win" the parsing.
+
 ### jju.stringify() function
 
 ```javascript

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -72,6 +72,7 @@ function parse(input, options) {
   // parse as a standard JSON mode
   var json5 = false
   var cjson = false
+  var no_duplicate_keys = options.no_duplicate_keys
 
   if (options.legacy || options.mode === 'json') {
     // use json
@@ -336,6 +337,9 @@ function parse(input, options) {
     while (position < length) {
       skipWhiteSpace()
       var item1 = parseKey()
+      if (no_duplicate_keys && result[item1]) {
+        fail('Duplicate key: ' + item1)
+      }
       skipWhiteSpace()
       tokenStart()
       var chr = input[position++]

--- a/test/test_parse.js
+++ b/test/test_parse.js
@@ -1,7 +1,7 @@
 var assert = require('assert')
 var parse = require('../').parse
 
-function addTest(arg, bulk) {
+function addTest(arg, bulk, json5) {
   function fn_json5() {
     //console.log('testing: ', arg)
     try {
@@ -33,11 +33,19 @@ function addTest(arg, bulk) {
   }
 
   if (typeof(describe) === 'function' && !bulk) {
-    it('test_parse_json5: ' + JSON.stringify(arg), fn_json5)
-    it('test_parse_strict: ' + JSON.stringify(arg), fn_strict)
+    if (json5 !== false) {
+      it('test_parse_json5: ' + JSON.stringify(arg), fn_json5)
+    }
+    if (json5 !== true) {
+      it('test_parse_strict: ' + JSON.stringify(arg), fn_strict)
+    }
   } else {
-    fn_json5()
-    fn_strict()
+    if (json5 !== false) {
+      fn_json5()
+    }
+    if (json5 !== true) {
+      fn_strict()
+    }
   }
 }
 
@@ -108,7 +116,11 @@ assert.strictEqual(parse(undefined), undefined)
 addTest('[1,\r\n2,\r3,\n]')
 '\x09\x0A\x0B\x0C\x0D\x20\xA0\uFEFF\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u2028\u2029\u202F\u205F\u3000'.split('').forEach(function(x) {
   addTest(x+'[1,'+x+'2]'+x)
-  addTest('"'+x+'"'+x)
+  // Do not test additional Unicode line separators, which are accepted
+  // as a usual whitespace by JavaScript parser, but JJU rejects them
+  // as line breaks, which must not appear inside a string value.
+  var json5 = x === '\u2028' || x === '\u2029' ? false : undefined
+  addTest('"'+x+'"'+x, undefined, json5)
 })
 '\u000A\u000D\u2028\u2029'.split('').forEach(function(x) {
   addTest(x+'[1,'+x+'2]'+x)

--- a/test/test_parse.js
+++ b/test/test_parse.js
@@ -154,6 +154,11 @@ if (process.version > 'v0.11.7') {
 
 assert.throws(parse.bind(null, "{-1:42}"))
 
+assert.deepEqual(parse('{ "key": 1, "key": 2}'), { key: 2 })
+assert.throws(function() {
+  parse('{ "key": 1, "key": 2}', { no_duplicate_keys: true })
+})
+
 for (var i=0; i<100; i++) {
   var str = '-01.e'.split('')
 


### PR DESCRIPTION
Attempts to fix #26. Based on #30, so that the tests succeed.

Introduce a new option `no_duplicate_keys` to report duplicate object keys as an error.