### PR TITLE
Improve quote analysis and fix trailing comma false positives

### DIFF
--- a/lib/analyze.js
+++ b/lib/analyze.js
@@ -4,6 +4,8 @@ var tokenize = require('./parse').tokenize
 module.exports.analyze = function analyzeJSON(input, options) {
   if (options == null) options = {}
 
+  const possible_multi_line_quotes = input.split('\n').filter(s => s.match(/\\$/))
+
   if (!Array.isArray(input)) {
     input = tokenize(input, options)
   }
@@ -11,6 +13,7 @@ module.exports.analyze = function analyzeJSON(input, options) {
   var result = {
     has_whitespace: false,
     has_comments: false,
+    has_multi_line_quote: false,
     has_newlines: false,
     has_trailing_comma: false,
     indent: '',
@@ -61,6 +64,17 @@ module.exports.analyze = function analyzeJSON(input, options) {
     }
 
     if (input[i].type === 'key' || input[i].type === 'literal') {
+      if (
+        possible_multi_line_quotes.length > 0 &&
+          !result.has_multi_line_quote
+      ) {
+        const splitRaw = input[i].raw.split('\n')
+        if (splitRaw.length > 1) {
+          result.has_multi_line_quote = possible_multi_line_quotes.some(s =>
+            s.endsWith(splitRaw[0])
+          )
+        }
+      }
       if (input[i].raw[0] === '"' || input[i].raw[0] === "'") {
         stats.quote[input[i].raw[0]] = (stats.quote[input[i].raw[0]] || 0) + 1
       }
@@ -82,6 +96,7 @@ module.exports.analyze = function analyzeJSON(input, options) {
     }
   }
 
+  result.quote_types = Object.keys(stats.quote)
+
   return result
 }
-

--- a/lib/analyze.js
+++ b/lib/analyze.js
@@ -4,7 +4,9 @@ var tokenize = require('./parse').tokenize
 module.exports.analyze = function analyzeJSON(input, options) {
   if (options == null) options = {}
 
-  const possible_multi_line_quotes = input.split('\n').filter(s => s.match(/\\$/))
+  const possible_multi_line_quotes = typeof input === 'string'
+    ? input.split('\n').filter(s => s.match(/\\$/))
+    : []
 
   if (!Array.isArray(input)) {
     input = tokenize(input, options)
@@ -27,6 +29,8 @@ module.exports.analyze = function analyzeJSON(input, options) {
     newline: {},
     quote: {},
   }
+
+  let bracketStack = []
 
   for (var i=0; i<input.length; i++) {
     if (input[i].type === 'newline') {
@@ -80,10 +84,35 @@ module.exports.analyze = function analyzeJSON(input, options) {
       }
     }
 
-    if (input[i].type === 'separator' && input[i].raw === ',') {
-      for (var j=i+1; j<input.length; j++) {
-        if (input[j].type === 'literal' || input[j].type === 'key') break
-        if (input[j].type === 'separator') result.has_trailing_comma = true
+    if (input[i].type === 'separator') {
+      switch (input[i].raw) {
+        case '{':
+        case '[':
+          bracketStack.push(input[i].raw)
+          break
+        case '}':
+        case ']':
+          bracketStack.pop()
+        default:
+          break
+      }
+      if (input[i].raw === ',') {
+        for (var j=i+1; j<input.length; j++) {
+          if (input[j].type === 'literal' || input[j].type === 'key') break
+          if (
+            input[j].type === 'separator' &&
+              (
+                (
+                  bracketStack[bracketStack.length - 1] === '[' &&
+                    input[j].raw !== '{'
+                ) || (
+                  bracketStack[bracketStack.length - 1] === '{'
+                )
+              )
+          ) {
+            result.has_trailing_comma = true
+          }
+        }
       }
     }
   }

--- a/test/test_analyze.js
+++ b/test/test_analyze.js
@@ -50,4 +50,27 @@ addTest(t.quote_keys, false)
 var t = analyze("{foo:'bar', \"bar\":'baz', \"baz\":\"quux\"}")
 addTest(t.quote, '"')
 addTest(t.quote_keys, false)
+addTest(t.has_multi_line_quote, false)
+addTest(t.quote_types[0], "'")
+addTest(t.quote_types[1], '"')
 
+var t = analyze(`
+{ foo: "ba\\
+r"}
+`)
+addTest(t.has_multi_line_quote, true)
+
+var t = analyze(`[{ foo: "bar", bar: "baz" }, { bar: "baz" }]`)
+addTest(t.has_trailing_comma, false)
+
+var t = analyze(`[{ foo: "bar", }, { bar: "baz" }]`)
+addTest(t.has_trailing_comma, true)
+
+var t = analyze(`[{ foo: "bar"}, { bar: "baz" },]`)
+addTest(t.has_trailing_comma, true)
+
+var t = analyze(`[1, 2]`)
+addTest(t.has_trailing_comma, false)
+
+var t = analyze(`[1, 2,]`)
+addTest(t.has_trailing_comma, true)


### PR DESCRIPTION
- add ability to detect multi-line quotes
- return list of all quote types
- fix a bug that was returning false positives for trailing commas in certain cases

The false positive was being generated for objects inside arrays. For example, the analyze function would return `has_trailing_comma: true` for the json: `[{ foo: "bar" }]`.